### PR TITLE
Removed filtering by mobile_app integration to allow any devices

### DIFF
--- a/AwtrixPhoneBattery.yaml
+++ b/AwtrixPhoneBattery.yaml
@@ -22,6 +22,7 @@ blueprint:
       description: Select the AWTRIX device
       selector:
         device:
+          multiple: true
           filter:
             - integration: mqtt
               manufacturer: Blueforcer
@@ -38,8 +39,7 @@ blueprint:
       selector:
         entity:
           filter:
-            - device_class: 
-                battery
+            - device_class: battery
     message_text:
       name: Text to display
       description: Text to be displayed on AWTRIX
@@ -142,11 +142,18 @@ blueprint:
 
 mode: restart
 variables:
-  device_id: !input awtrix
+  device_ids: !input awtrix
   app: !input app_name
-  awtrix:
-    "{{ iif( device_attr(device_id, 'name_by_user') != none, device_attr(device_id,
-    'name_by_user'), device_attr(device_id, 'name') ) }}"
+  devices_topics: >-
+    {%- macro get_device_topic(device_id) %} 
+    {{- states((device_entities(device_id) | select('search','device_topic') | list)[0]) }}
+    {%- endmacro %}
+    {%- set ns = namespace(devices=[]) %} 
+    {%- for device_id in device_ids %}
+    {%- set device=get_device_topic(device_id)|replace(' ','') %}
+    {% set ns.devices = ns.devices + [ device ~ '/custom/' ~ app] %}
+    {%- endfor %}
+    {{ ns.devices | reject('match','unavailable') | list}}
 
   battery_sensor: !input battery
   message_text: !input message_text
@@ -181,11 +188,14 @@ trigger:
     minutes: /1
 
 condition: []
+
 action:
-  service: mqtt.publish
-  data:
-    qos: 0
-    retain: false
-    topic: "{{awtrix}}/custom/{{app}}"
-    payload: >
-      {{payload}}
+  - repeat:
+      for_each: "{{ devices_topics }}"
+      sequence:
+        - service: mqtt.publish
+          data:
+            qos: 0
+            retain: false
+            topic: "{{ repeat.item }}"
+            payload: "{{payload}}"

--- a/AwtrixPhoneBattery.yaml
+++ b/AwtrixPhoneBattery.yaml
@@ -27,7 +27,7 @@ blueprint:
               manufacturer: Blueforcer
               model: AWTRIX 3
     app_name:
-      name: AWTRIX Applicaiton name
+      name: AWTRIX Application name
       description: This is the app name listed in the MQTT topic - it should be unique
       selector:
         text:
@@ -38,8 +38,8 @@ blueprint:
       selector:
         entity:
           filter:
-            - integration: mobile_app
-              device_class: battery
+            - device_class: 
+                battery
     message_text:
       name: Text to display
       description: Text to be displayed on AWTRIX


### PR DESCRIPTION
Removed filtering by mobile_app integration to allow any devices with battery class, e.g. robot lawnmower, vacuum cleaner, car or anything else.